### PR TITLE
Fix CSV export missing BOM function

### DIFF
--- a/CustomCodebookModule.php
+++ b/CustomCodebookModule.php
@@ -145,7 +145,7 @@ class CustomCodebookModule extends AbstractExternalModule
         header("Content-type: application/csv");
         header("Content-Disposition: attachment; filename=$filename");
         // Output the file contents
-        print addBOMtoUTF8($this->generateCSVFile($project_id));
+        print $this->addBOMtoUTF8($this->generateCSVFile($project_id));
     }
 
     private function generateCSVFile($project_id): string|array|bool     {
@@ -205,6 +205,12 @@ class CustomCodebookModule extends AbstractExternalModule
         // Replace CR+LF with just LF for better compatibility with Excel on Macs
         $content = str_replace("\r\n", "\n", $content);
         return $content;
+    }
+
+    private function addBOMtoUTF8(string $data): string
+    {
+        $bom = "\xEF\xBB\xBF";
+        return (substr($data, 0, 3) === $bom) ? $data : $bom . $data;
     }
 
     // ******************************************************************************************


### PR DESCRIPTION
## Summary
- fix call to undefined `addBOMtoUTF8` during CSV export
- implement helper method to prefix UTF‑8 BOM

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e6c207b8832b9c40f735ed86f339